### PR TITLE
Pundit & authorization on Assignments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "image_processing", "~> 1.2"
 
 # Authentication and authorization
 gem 'devise'
+gem 'pundit'
 
 # UI Gems
 gem 'friendly_id'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-mini-profiler (3.0.0)
@@ -307,6 +309,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry (~> 0.13.1)
   puma (~> 5.0)
+  pundit
   rack-mini-profiler
   rails (~> 7.0.2, >= 7.0.2.2)
   redis (~> 4.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@
 # Get off my back Rubocop, we all know what this is
 class ApplicationController < ActionController::Base
   include SetAuthenticatedMember
+  include Pundit::Authorization
+
   before_action :authenticate_member!
 
   before_action :configure_permitted_paramters, if: :devise_controller?

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -5,10 +5,6 @@
 class AssignmentsController < ApplicationController
   before_action :set_assignment, only: %i[show edit update destroy]
 
-  # All Assignment actions should be authorized for captains only
-  # with the exception of mark_pending_review
-  before_action :check_if_captain, except: :mark_pending_review
-
   # GET /assignments or /assignments.json
   def index
     @assignments = Assignment.all
@@ -21,6 +17,9 @@ class AssignmentsController < ApplicationController
   # GET /assignments/new
   def new
     @assignment = Assignment.new
+
+    authorize @assignment
+
     @members    = Member.all
     @tasks      = Task.all
 
@@ -29,6 +28,8 @@ class AssignmentsController < ApplicationController
 
   # GET /assignments/1/edit
   def edit
+    authorize @assignment
+
     @members = Member.all
     @tasks   = Task.all
   end
@@ -36,6 +37,8 @@ class AssignmentsController < ApplicationController
   # POST /assignments or /assignments.json
   def create
     @assignment = Assignment.new(assignment_params)
+
+    authorize @asignnment
 
     respond_to do |format|
       if @assignment.save
@@ -52,6 +55,8 @@ class AssignmentsController < ApplicationController
 
   # PATCH/PUT /assignments/1 or /assignments/1.json
   def update
+    authorize @assignment
+
     respond_to do |format|
       if @assignment.update(assignment_params)
         format.html { redirect_to assignment_url(@assignment), notice: 'Member task was successfully updated.' }
@@ -66,6 +71,8 @@ class AssignmentsController < ApplicationController
   # DELETE /assignments/1 or /assignments/1.json
   # TODO: Soft delete instead
   def destroy
+    authorize @assignment
+
     @assignment.destroy
 
     respond_to do |format|
@@ -75,13 +82,12 @@ class AssignmentsController < ApplicationController
   end
 
   # PUT /assignments/:id/mark_pending_review
-  # TODO: Pundit policy - Any member should be able to mark their own assignments
-  #                       as pending review (if its current status is in_progress)
-  #                       and captains should be able to do whatever they want
   # TODO: Handle rerendering the Show view with a turbo stream
   # TODO: Handle receiving an optional note
   def mark_pending_review
     assignment = Assignment.find(params[:assignment_id])
+
+    authorize assignment
 
     if assignment.mark_pending_review
       data = { message: "This #{assignment.task.category.capitalize} has been marked as 'Pending Review' and is awaiting approval" }
@@ -93,13 +99,12 @@ class AssignmentsController < ApplicationController
   end
 
   # PUT /assignments/:id/mark_in_progress
-  # TODO: Pundit policy - Any member should be able to mark their own assignments
-  #                       as in_progress (if its current status is pending_review)
-  #                       and captains should be able to do whatever they want
   # TODO: Handle rerendering the Show view with a turbo stream
   # TODO: Handle receiving an optional note
   def mark_in_progress
     assignment = Assignment.find(params[:assignment_id])
+
+    authorize assignment
 
     if assignment.mark_in_progress
       data = { message: "This #{assignment.task.category.capitalize} has been marked as 'In Progress'" }
@@ -111,11 +116,12 @@ class AssignmentsController < ApplicationController
   end
 
   # PUT /assignments/:id/mark_complete
-  # TODO: add Pundit authorization here to make sure member is captain
   # TODO: Handle rerendering the Show view with a turbo stream
   # TODO: Handle receiving an optional note
   def mark_complete
     assignment = Assignment.find(params[:assignment_id])
+
+    authorize assignment
 
     if assignment.mark_complete
       data = { message: "This #{assignment.task.category.capitalize} has been marked as 'Complete'" }
@@ -127,11 +133,12 @@ class AssignmentsController < ApplicationController
   end
 
   # PUT /assignments/:id/mark_failed
-  # TODO: add Pundit authorization here to make sure member is captain
   # TODO: Handle rerendering the Show view with a turbo stream
   # TODO: Handle receiving an optional note
   def mark_failed
     assignment = Assignment.find(params[:assignment_id])
+
+    authorize assignment
 
     if assignment.mark_failed
       data = { message: "This #{assignment.task.category.capitalize} has been marked as 'Failed'" }
@@ -158,10 +165,5 @@ class AssignmentsController < ApplicationController
                                        consequence_attributes: [:value,
                                                                 :duration,
                                                                 :category])
-  end
-
-  # TODO: Extract to application controller and document
-  def check_if_captain
-    current_member.captain?
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :member, :record
+
+  def initialize(member, record)
+    @member = member
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(member, scope)
+      @member = member
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :member, :scope
+  end
+end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Class to handle authorization via Pundit policies on Assignments
+class AssignmentPolicy < ApplicationPolicy
+  # Only captains should be able to create an assignment
+  #
+  # @return [Boolean]  
+  def create?
+    @member.captain?
+  end
+
+  # Only captains should be able to create an assignment
+  #
+  # @return [Boolean]
+  def new?
+    create?
+  end
+
+  # Only captains should be able to update an assignment
+  #
+  # @return [Boolean]
+  def update?
+    @member.captain?
+  end
+
+  # Only captains should be able to update an assignment
+  #
+  # @return [Boolean]
+  def edit?
+    update?
+  end
+
+  # Only captains should be able to destroy an assignment
+  #
+  # @return [Boolean]
+  def destroy?
+    @member.captain?
+  end
+
+  # If the member is a captain, they should be able to update an assignment's
+  # status to :pending review regardless of it's current status and who the
+  # assignment belongs to. If the member is a member, they should only be
+  # able to mark an assignment as :pending_review if its current status is
+  # :in_progress and the assignment belongs to them.
+  #
+  # @return [Boolean]
+  def mark_pending_review?
+    return true if @member.captain?
+
+    @record.member_id == @member.id && @record.in_progress?
+  end
+
+  # If the member is a captain, they should be able to update an assignment's
+  # status to :in_progress regardless of it's current status and who the assignment
+  # belongs to. If the member is a member, they should only be able to mark an
+  # assignment as :in_progress if its current status is :pending_review and the
+  # assignment belongs to them.
+  #
+  # @return [Boolean]
+  def mark_in_progress?
+    return true if @member.captain?
+
+    @record.member_id == @member.id && @record.pending_review?
+  end
+
+  # Only captains should be able to mark an assignment complete
+  #
+  # @return [Boolean]
+  def mark_complete?
+    @member.captain?
+  end
+
+  # Only captains should be able to mark an assignment failed
+  #
+  # @return [Boolean]
+  def mark_failed?
+    @member.captain?
+  end
+end

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -73,7 +73,7 @@
     </div>
 
     <div class="flex w-full mt-6 border-container">
-      <%= @assignment.consequence.pretty_consequence %>
+      <%= @assignment.consequence.pretty_consequence if @assignment.consequence %>
     </div>
 
     <br/>

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Assignment, type: :model do
   fixtures :crew
 
   before(:each) do
-    crew = crew(:test_crew)
-    @member = FactoryBot.create(:member, crew: crew, role: 'member')
-    @captain = FactoryBot.create(:member, crew: crew,
+    @crew = crew(:test_crew)
+    @member = FactoryBot.create(:member, crew: @crew, role: 'member')
+    @captain = FactoryBot.create(:member, crew: @crew,
                                           role: 'captain',
                                           email: 'captain@captain.com')
     Current.crew = crew
@@ -36,9 +36,9 @@ RSpec.describe Assignment, type: :model do
   describe 'status' do
     context 'is in_progress' do
       context 'and member' do
-        it 'should be able to change it to pending_review' do
+        it 'should be able to change status to pending_review' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -56,9 +56,9 @@ RSpec.describe Assignment, type: :model do
           expect(assignment).to have_state(:pending_review).on(:status)
         end
 
-        it 'should not be able to change it to complete' do
+        it 'should not be able to change status to complete' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -77,9 +77,9 @@ RSpec.describe Assignment, type: :model do
           expect(assignment).to have_state(:in_progress).on(:status)
         end
 
-        it 'should not be able to change it to failed' do
+        it 'should not be able to change status to failed' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -97,12 +97,83 @@ RSpec.describe Assignment, type: :model do
           expect(assignment).not_to transition_from(:in_progress).to(:failed).on_event(:mark_failed).on(:status)
           expect(assignment).to have_state(:in_progress).on(:status)
         end
+
+        it 'should not be able to change status if it doesnt belong to them' do
+          Current.member    = @member
+          task              = create(:task)
+          some_other_member = FactoryBot.create(:member, first_name: 'some other',
+                                                         last_name: 'member',
+                                                         crew: @crew,
+                                                         email: 'someothermember@example.com',
+                                                         role: 'member')
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: some_other_member,
+                                                      reward_applied: false,
+                                                      status: 'in_progress')
+
+          # Test the following:
+          # - initial state is 'in_progress'
+          # - since this assignment doesnt belong to @member, they should not
+          #   be able to update it and we should never run the
+          #   :update_pending_review callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'in_progress'
+          expect(assignment).to have_state(:in_progress).on(:status)
+          expect(assignment).not_to receive(:update_in_progress)
+          expect(assignment).not_to transition_from(:in_progress).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:in_progress).on(:status)
+        end
+
+        it 'should not be able to change status if its already marked complete' do
+          Current.member    = @member
+          task              = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is :complete
+          # - since this assignment is already marked :complete, a member should
+          #   not have the authorization to move it back to :pending_review
+          # - the :update_complete callback should not be called
+          # - the state machine' transition is not successful
+          # - the status never changes and remains :complete
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).not_to receive(:update_complete)
+          expect(assignment).not_to transition_from(:complete).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
+        end
+
+        it 'should not be able to change status if its already marked failed' do
+          Current.member    = @member
+          task              = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is :failed
+          # - since this assignment is already marked :failed, a member should
+          #   not have the authorization to move it back to :pending_review
+          # - the :update_failed callback should not be called
+          # - the state machine' transition is not successful
+          # - the status never changes and remains :failed
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).not_to receive(:update_failed)
+          expect(assignment).not_to transition_from(:failed).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:failed).on(:status)
+        end
       end
 
       context 'and captain' do
-        it 'should be able to change it to pending_review' do
+        it 'should be able to change status to pending_review' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -113,16 +184,16 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'in_progress'
           # - when we run the :mark_pending_review event, we call the :update_pending_review callback
           # - the state machine's transition is successful
-          # - the resulting state is 'pending_review'
+          # - the resulting status is 'pending_review'
           expect(assignment).to have_state(:in_progress).on(:status)
           expect(assignment).to receive(:update_pending_review)
           expect(assignment).to transition_from(:in_progress).to(:pending_review).on_event(:mark_pending_review).on(:status)
           expect(assignment).to have_state(:pending_review).on(:status)
         end
 
-        it 'should be able to change it to complete' do
+        it 'should be able to change status to complete' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -133,16 +204,16 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'in_progress'
           # - when we run the :mark_complete event, we call the :update_complete callback
           # - the state machine's transition is successful
-          # - the resulting state is 'complete'
+          # - the resulting status is 'complete'
           expect(assignment).to have_state(:in_progress).on(:status)
           expect(assignment).to receive(:update_complete)
           expect(assignment).to transition_from(:in_progress).to(:complete).on_event(:mark_complete).on(:status)
           expect(assignment).to have_state(:complete).on(:status)
         end
 
-        it 'should be able to change it to failed' do
+        it 'should be able to change status to failed' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -153,7 +224,7 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'in_progress'
           # - when we run the :mark_failed event, we call the :update_failed callback
           # - the state machine's transition is successful
-          # - the resulting state is 'failed'
+          # - the resulting status is 'failed'
           expect(assignment).to have_state(:in_progress).on(:status)
           expect(assignment).to receive(:update_failed)
           expect(assignment).to transition_from(:in_progress).to(:failed).on_event(:mark_failed).on(:status)
@@ -164,9 +235,9 @@ RSpec.describe Assignment, type: :model do
 
     context 'is pending_review' do
       context 'and member' do
-        it 'should be able to change it to in_progress' do
+        it 'should be able to change status to in_progress' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -176,16 +247,16 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'pending_review'
           # - when we run the :mark_in_progress event, we call the :update_in_progress callback
           # - the state machine's transition is successful
-          # - the resulting state is 'in_progress'
+          # - the resulting status is 'in_progress'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).to receive(:update_in_progress)
           expect(assignment).to transition_from(:pending_review).to(:in_progress).on_event(:mark_in_progress).on(:status)
           expect(assignment).to have_state(:in_progress).on(:status)
         end
 
-        it 'should not be able to change it to complete' do
+        it 'should not be able to change status to complete' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -197,16 +268,16 @@ RSpec.describe Assignment, type: :model do
           # - since a member should not be able to mark this assignment as complete,
           #   we should never run the :update_complete callback
           # - the state machine's transition is not successful
-          # - the state never changes and remains as 'pending_review'
+          # - the status never changes and remains as 'pending_review'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).not_to receive(:update_complete)
           expect(assignment).not_to transition_from(:pending_review).to(:in_progress).on_event(:mark_complete).on(:status)
           expect(assignment).to have_state(:pending_review).on(:status)
         end
 
-        it 'should not be able to change it to failed' do
+        it 'should not be able to change status to failed' do
           Current.member = @member
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -218,18 +289,45 @@ RSpec.describe Assignment, type: :model do
           # - since a member should not be able to mark this assignment as failed,
           #   we should never run the :update_failed callback
           # - the state machine's transition is not successful
-          # - the state never changes and remains as 'pending_review'
+          # - the status never changes and remains as 'pending_review'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).not_to receive(:update_failed)
           expect(assignment).not_to transition_from(:pending_review).to(:in_progress).on_event(:mark_failed).on(:status)
           expect(assignment).to have_state(:pending_review).on(:status)
         end
+
+        it 'should not be able to change status if it doesnt belong to them' do
+          Current.member    = @member
+          task              = create(:task)
+          some_other_member = FactoryBot.create(:member, first_name: 'some other',
+                                                         last_name: 'member',
+                                                         crew: @crew,
+                                                         email: 'someothermember@example.com',
+                                                         role: 'member')
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: some_other_member,
+                                                      reward_applied: false,
+                                                      status: 'pending_review')
+
+          # Test the following:
+          # - initial state is 'pending_review'
+          # - since this assignment doesnt belong to @member, they should not
+          #   be able to update it and we should never run the
+          #   :update_pending_review callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'pending_review'
+          expect(assignment).to have_state(:pending_review).on(:status)
+          expect(assignment).not_to receive(:update_pending_review)
+          expect(assignment).not_to transition_from(:pending_review).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:pending_review).on(:status)
+        end
       end
 
       context 'and captain' do
-        it 'should be able to change it to in_progress' do
+        it 'should be able to change status to in_progress' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -240,16 +338,16 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'pending_review'
           # - when we run the :mark_in_progress event, we call the :update_in_progress callback
           # - the state machine's transition is successful
-          # - the resulting state is 'in_progress'
+          # - the resulting status is 'in_progress'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).to receive(:update_in_progress)
           expect(assignment).to transition_from(:pending_review).to(:in_progress).on_event(:mark_in_progress).on(:status)
           expect(assignment).to have_state(:in_progress).on(:status)
         end
 
-        it 'should be able to change it to complete' do
+        it 'should be able to change status to complete' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -260,16 +358,16 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'pending_review'
           # - when we run the :mark_complete event, we call the :update_complete callback
           # - the state machine's transition is successful
-          # - the resulting state is 'complete'
+          # - the resulting status is 'complete'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).to receive(:update_complete)
           expect(assignment).to transition_from(:pending_review).to(:complete).on_event(:mark_complete).on(:status)
           expect(assignment).to have_state(:complete).on(:status)
         end
 
-        it 'should be able to change it to failed' do
+        it 'should be able to change status to failed' do
           Current.member = @captain
-          task = create(:task)
+          task           = create(:task)
 
           assignment = FactoryBot.create(:assignment, task: task,
                                                       member: @member,
@@ -280,11 +378,296 @@ RSpec.describe Assignment, type: :model do
           # - initial state is 'pending review'
           # - when we run the :mark_failed event, we call the :update_failed callback
           # - the state machine's transition is successful
-          # - the resulting state is 'failed'
+          # - the resulting status is 'failed'
           expect(assignment).to have_state(:pending_review).on(:status)
           expect(assignment).to receive(:update_failed)
           expect(assignment).to transition_from(:pending_review).to(:failed).on_event(:mark_failed).on(:status)
           expect(assignment).to have_state(:failed).on(:status)
+        end
+      end
+    end
+  
+    context 'is complete' do
+      context 'and member' do
+        it 'should not be able to change status to in_progress' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - since a member should not be able to mark this assignment as complete,
+          #   we should never run the :update_in_progress callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'complete'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).not_to receive(:update_in_progress)
+          expect(assignment).not_to transition_from(:complete).to(:in_progress).on_event(:mark_in_progress).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
+        end
+
+        it 'should not be able to change status to pending_review' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - since a member should not be able to mark this assignment as pending_review,
+          #   we should never run the :update_pending_review callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'complete'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).not_to receive(:update_pending_review)
+          expect(assignment).not_to transition_from(:complete).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
+        end
+
+        it 'should not be able to change status to failed' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - since a member should not be able to mark this assignment as failed,
+          #   we should never run the :update_failed callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'complete'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).not_to receive(:update_failed)
+          expect(assignment).not_to transition_from(:complete).to(:failed).on_event(:mark_failed).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
+        end
+
+        it 'should not be able to change status if it doesnt belong to them' do
+          Current.member    = @member
+          task              = create(:task)
+          some_other_member = FactoryBot.create(:member, first_name: 'some other',
+                                                         last_name: 'member',
+                                                         crew: @crew,
+                                                         email: 'someothermember@example.com',
+                                                         role: 'member')
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: some_other_member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - since this assignment doesnt belong to @member, they should not
+          #   be able to update it and we should never run the
+          #   :update_pending_review callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'complete'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).not_to receive(:update_pending_review)
+          expect(assignment).not_to transition_from(:complete).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
+        end
+      end
+
+      context 'and captain' do
+        it 'should be able to change status to in_progress' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - when we run the :mark_in_progress event, we call the :update_in_progress callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'in_progress'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).to receive(:update_in_progress)
+          expect(assignment).to transition_from(:complete).to(:in_progress).on_event(:mark_in_progress).on(:status)
+          expect(assignment).to have_state(:in_progress).on(:status)
+        end
+
+        it 'should be able to change status to failed' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - when we run the :mark_failed event, we call the :update_failed callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'failed'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).to receive(:update_failed)
+          expect(assignment).to transition_from(:complete).to(:failed).on_event(:mark_failed).on(:status)
+          expect(assignment).to have_state(:failed).on(:status)
+        end
+
+        it 'should be able to change status to pending_review' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'complete')
+
+          # Test the following:
+          # - initial state is 'complete'
+          # - when we run the :mark_pending_review event, we call the :update_pending_review callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'pending_review'
+          expect(assignment).to have_state(:complete).on(:status)
+          expect(assignment).to receive(:update_pending_review)
+          expect(assignment).to transition_from(:complete).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:pending_review).on(:status)
+        end
+      end
+    end
+
+    context 'is failed' do
+      context 'and member' do
+        it 'should not be able to change status to in_progress' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - since a member should not be able to mark this assignment as failed,
+          #   we should never run the :update_failed callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'failed'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).not_to receive(:update_failed)
+          expect(assignment).not_to transition_from(:failed).to(:failed).on_event(:mark_failed).on(:status)
+          expect(assignment).to have_state(:failed).on(:status)
+        end
+
+        it 'should not be able to change status to pending_review' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - since a member should not be able to mark this assignment as pending_review,
+          #   we should never run the :update_pending_review callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'failed'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).not_to receive(:update_pending_review)
+          expect(assignment).not_to transition_from(:failed).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:failed).on(:status)
+        end
+
+        it 'should not be able to change status to complete' do
+          Current.member = @member
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - since a member should not be able to mark this assignment as failed,
+          #   we should never run the :update_complete callback
+          # - the state machine's transition is not successful
+          # - the status never changes and remains as 'failed'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).not_to receive(:update_complete)
+          expect(assignment).not_to transition_from(:failed).to(:failed).on_event(:mark_complete).on(:status)
+          expect(assignment).to have_state(:failed).on(:status)
+        end
+      end
+
+      context 'and captain' do
+        it 'should be able to change status to in_progress' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - when we run the :mark_in_progress event, we call the :update_in_progress callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'in_progress'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).to receive(:update_in_progress)
+          expect(assignment).to transition_from(:failed).to(:in_progress).on_event(:mark_in_progress).on(:status)
+          expect(assignment).to have_state(:in_progress).on(:status)
+        end
+
+        it 'should be able to change status to pending_review' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - when we run the :mark_pending_review event, we call the :update_pending_review callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'pending_review'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).to receive(:update_pending_review)
+          expect(assignment).to transition_from(:failed).to(:pending_review).on_event(:mark_pending_review).on(:status)
+          expect(assignment).to have_state(:pending_review).on(:status)
+        end
+
+        it 'should be able to change status to complete' do
+          Current.member = @captain
+          task           = create(:task)
+
+          assignment = FactoryBot.create(:assignment, task: task,
+                                                      member: @member,
+                                                      reward_applied: false,
+                                                      status: 'failed')
+
+          # Test the following:
+          # - initial state is 'failed'
+          # - when we run the :mark_complete event, we call the :update_complete callback
+          # - the state machine's transition is successful
+          # - the resulting status is 'complete'
+          expect(assignment).to have_state(:failed).on(:status)
+          expect(assignment).to receive(:update_complete)
+          expect(assignment).to transition_from(:failed).to(:complete).on_event(:mark_complete).on(:status)
+          expect(assignment).to have_state(:complete).on(:status)
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,10 @@ RSpec.configure do |config|
 
   # factory_bot gem testing configurations
   config.include FactoryBot::Syntax::Methods
+
+  # Include Devise test helpers so we can sign in/out members
+  # https://github.com/heartcombo/devise/wiki/How-To:-sign-in-and-out-a-user-in-Request-type-specs-(specs-tagged-with-type:-:request)#1-simple-approach
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 # Configure shoulda matchers

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for the assignments controller
+RSpec.describe '/assignments', type: :request do
+  fixtures :crew
+
+  before(:each) do
+    crew = crew(:test_crew)
+    @member = FactoryBot.create(:member, crew: crew, role: 'member')
+    @captain = FactoryBot.create(:member, crew: crew,
+                                          role: 'captain',
+                                          email: 'captain@captain.com')
+    Current.crew = crew
+  end
+
+  describe 'GET /assignments' do
+    context 'member' do
+      it 'should render a successful response' do
+        Current.member = @member
+        sign_in @member
+
+        get assignments_url
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'captain' do
+      it 'should render a successful response' do
+        Current.member = @captain
+        sign_in @captain
+
+        get assignments_url
+
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'GET /assignments/:id' do
+    context 'member' do
+      it 'should render a successful response' do
+        Current.member = @member
+        sign_in @member
+
+        task = create(:task)
+
+        assignment = FactoryBot.create(:assignment, task: task,
+                                                    member: @member,
+                                                    reward_applied: false,
+                                                    status: 'in_progress')
+
+        get assignment_url(assignment)
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'captain' do
+      it 'should render a successful response' do
+        Current.member = @captain
+        sign_in @captain
+
+        task = create(:task)
+
+        assignment = FactoryBot.create(:assignment, task: task,
+                                                    member: @member,
+                                                    reward_applied: false,
+                                                    status: 'in_progress')
+
+        get assignment_url(assignment)
+
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added Pundit and created a policy for Assignments. Stuck those policies in the Assignments controller and in the Assignment AASM for status.

1 or 2 tests to go along with it.